### PR TITLE
fix: recuperar archivos Designer de migraciones, CORS en local y datos de demostracion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,14 @@ out/
 # Entity Framework Core
 efpt.config.json
 efpt.renaming.json
-migrations/*.Designer.cs
-*.Designer.cs
+
+# NO ignorar los archivos .Designer.cs de las migraciones.
+#
+# Ese archivo es el que lleva el atributo [Migration]; sin el, EF Core no
+# reconoce la clase como migracion y la salta en silencio, informando que la
+# base "ya esta al dia". Esa regla dejo 22 de 23 migraciones inservibles y
+# obligo a colapsar el historial; al no retirarla, la primera migracion nueva
+# del equipo volvio a caer en lo mismo.
 
 # NuGet
 *.nupkg

--- a/LAMAMedellin/src/LAMAMedellin.API/Program.cs
+++ b/LAMAMedellin/src/LAMAMedellin.API/Program.cs
@@ -84,9 +84,17 @@ if (app.Environment.IsDevelopment())
 
 app.UseExceptionHandler();
 
-app.UseHttpsRedirection();
-
+// CORS va antes de cualquier redireccion: si el preflight OPTIONS se responde
+// con un redirect, el navegador lo rechaza sin siquiera mirar las cabeceras.
 app.UseCors("NextJsCors");
+
+// En Development la API escucha en HTTP plano, asi que redirigir a HTTPS
+// rompia todas las llamadas del frontend con
+// "Redirect is not allowed for a preflight request".
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHttpsRedirection();
+}
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260727233255_Baseline.Designer.cs
+++ b/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260727233255_Baseline.Designer.cs
@@ -4,6 +4,7 @@ using LAMAMedellin.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LAMAMedellin.Infrastructure.Migrations
 {
     [DbContext(typeof(LamaDbContext))]
-    partial class LamaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260727233255_Baseline")]
+    partial class Baseline
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -34,25 +37,11 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("ComprobanteId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<Guid>("CuentaContableId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<decimal>("Debe")
                         .HasColumnType("decimal(18,2)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<decimal>("Haber")
                         .HasColumnType("decimal(18,2)");
@@ -67,13 +56,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<Guid?>("TerceroId")
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -100,23 +82,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaAplicadaCOP")
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<Guid>("EventoId")
                         .HasColumnType("uniqueidentifier");
 
@@ -129,13 +94,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<string>("Observaciones")
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -153,35 +111,8 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<Guid>("CuentaContableId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<bool>("EsActivo")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(true);
-
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
-
-                    b.Property<string>("Nombre")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("NumeroCuenta")
                         .IsRequired()
@@ -192,16 +123,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
-
-                    b.HasIndex("CuentaContableId");
 
                     b.HasIndex("NumeroCuenta")
                         .IsUnique();
@@ -214,20 +136,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Email")
                         .IsRequired()
@@ -263,13 +171,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(30)
                         .HasColumnType("nvarchar(30)");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
                     b.HasIndex("ProyectoSocialId");
@@ -280,25 +181,43 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.ToTable("Beneficiarios", (string)null);
                 });
 
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.CentroCosto", b =>
+            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Caja", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
+                    b.Property<Guid>("CuentaContableId")
+                        .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
 
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                    b.Property<string>("Nombre")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("nvarchar(150)");
 
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                    b.Property<decimal>("SaldoActual")
+                        .HasPrecision(18, 2)
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<int>("TipoCaja")
+                        .HasColumnType("int");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CuentaContableId")
+                        .IsUnique();
+
+                    b.ToTable("Cajas", (string)null);
+                });
+
+            modelBuilder.Entity("LAMAMedellin.Domain.Entities.CentroCosto", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
@@ -311,13 +230,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<int>("Tipo")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
                     b.ToTable("CentrosCosto", (string)null);
@@ -328,20 +240,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Descripcion")
                         .IsRequired()
@@ -365,13 +263,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<int>("TipoComprobante")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
                     b.HasIndex("NumeroConsecutivo")
@@ -386,22 +277,8 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<Guid>("CuentaContableIngresoId")
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
@@ -413,13 +290,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<int>("PeriodicidadMensual")
                         .HasColumnType("int");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<decimal>("ValorCOP")
                         .HasColumnType("decimal(18,2)");
@@ -434,19 +304,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.ToTable("ConceptosCobro", (string)null);
                 });
 
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.ConsecutivoComprobante", b =>
-                {
-                    b.Property<int>("TipoComprobante")
-                        .HasColumnType("int");
-
-                    b.Property<int>("UltimoNumero")
-                        .HasColumnType("int");
-
-                    b.HasKey("TipoComprobante");
-
-                    b.ToTable("ConsecutivosComprobante", (string)null);
-                });
-
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.CuentaContable", b =>
                 {
                     b.Property<Guid>("Id")
@@ -458,22 +315,8 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(20)
                         .HasColumnType("nvarchar(20)");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<Guid?>("CuentaPadreId")
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Descripcion")
                         .IsRequired()
@@ -491,13 +334,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<bool>("PermiteMovimiento")
                         .HasColumnType("bit");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -520,20 +356,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasColumnType("uniqueidentifier")
                         .HasDefaultValue(new Guid("00000000-0000-0000-0000-000000000000"));
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<int>("Estado")
                         .HasColumnType("int");
 
@@ -553,22 +375,10 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("MiembroId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("Periodo")
-                        .IsRequired()
-                        .HasMaxLength(7)
-                        .HasColumnType("nvarchar(7)");
-
                     b.Property<decimal>("SaldoPendiente")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("decimal(18,2)")
                         .HasDefaultValue(0m);
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<decimal>("ValorTotal")
                         .ValueGeneratedOnAdd()
@@ -579,9 +389,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasIndex("ConceptoCobroId");
 
-                    b.HasIndex("MiembroId", "ConceptoCobroId", "Periodo")
+                    b.HasIndex("MiembroId", "ConceptoCobroId", "FechaEmision")
                         .IsUnique()
-                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoPeriodo");
+                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoFecha");
 
                     b.ToTable("CuentasPorCobrar", (string)null);
                 });
@@ -599,35 +409,11 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<int>("Anio")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
                     b.Property<int>("MesInicioCobro")
                         .HasColumnType("int");
-
-                    b.Property<decimal?>("RenovacionMembresiaUSD")
-                        .HasColumnType("decimal(18,4)");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<decimal>("ValorMensualCOP")
                         .HasColumnType("decimal(18,2)");
@@ -657,20 +443,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<Guid>("DonanteId")
                         .HasColumnType("uniqueidentifier");
 
@@ -691,13 +463,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<decimal>("MontoCOP")
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
                     b.HasIndex("BancoId");
@@ -717,20 +482,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Email")
                         .IsRequired()
@@ -756,13 +507,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<int>("TipoPersona")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
                     b.HasIndex("TipoDocumento", "NumeroDocumento")
@@ -777,7 +521,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("BancoId")
+                    b.Property<Guid>("CajaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("CentroCostoId")
@@ -791,31 +535,14 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<Guid>("CuentaContableId")
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<DateTime>("Fecha")
                         .HasColumnType("datetime2");
 
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
-
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
 
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
@@ -824,16 +551,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid?>("TerceroId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
-                    b.HasIndex("BancoId");
+                    b.HasIndex("CajaId");
 
                     b.HasIndex("CentroCostoId");
 
@@ -849,23 +569,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaLogisticaCOP")
-                        .HasColumnType("decimal(18,2)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Descripcion")
                         .IsRequired()
@@ -900,13 +603,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<int>("TipoEvento")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
                     b.ToTable("Eventos", (string)null);
@@ -918,7 +614,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("BancoId")
+                    b.Property<Guid>("CajaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("CentroCostoId")
@@ -932,31 +628,14 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<Guid>("CuentaContableId")
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<DateTime>("Fecha")
                         .HasColumnType("datetime2");
 
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
-
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
 
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
@@ -965,16 +644,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid?>("TerceroId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
-                    b.HasIndex("BancoId");
+                    b.HasIndex("CajaId");
 
                     b.HasIndex("CentroCostoId");
 
@@ -1003,20 +675,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<int>("Cilindraje")
                         .HasColumnType("int");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("DocumentoIdentidad")
                         .IsRequired()
@@ -1069,20 +727,8 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(30)
                         .HasColumnType("nvarchar(30)");
 
-                    b.Property<int>("TipoAfiliacion")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(3);
-
                     b.Property<int>("TipoSangre")
                         .HasColumnType("int");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -1106,20 +752,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(200)
                         .HasColumnType("nvarchar(200)");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<DateTime>("Fecha")
                         .HasColumnType("datetime2");
 
@@ -1138,13 +770,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<int>("TipoMovimiento")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
                     b.HasIndex("Fecha")
@@ -1153,68 +778,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.HasIndex("ProductoId");
 
                     b.ToTable("MovimientosInventario", (string)null);
-                });
-
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.PeriodoContable", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<int>("Anio")
-                        .HasColumnType("int");
-
-                    b.Property<string>("CerradoPor")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<int>("Estado")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime?>("FechaCierre")
-                        .HasColumnType("datetime2");
-
-                    b.Property<DateTime?>("FechaValidacionTesoreria")
-                        .HasColumnType("datetime2");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
-
-                    b.Property<int>("Mes")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<string>("ValidadoPor")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Anio", "Mes")
-                        .IsUnique()
-                        .HasDatabaseName("IX_PeriodosContables_AnioMes");
-
-                    b.ToTable("PeriodosContables", (string)null);
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Producto", b =>
@@ -1238,22 +801,8 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<Guid>("CuentaContableIngresoId")
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("ImageUrl")
                         .HasMaxLength(2048)
@@ -1272,13 +821,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<decimal>("PrecioVenta")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -1299,20 +841,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<Guid>("CentroCostoId")
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Descripcion")
                         .IsRequired()
@@ -1340,13 +868,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
                     b.HasIndex("CentroCostoId");
@@ -1360,32 +881,11 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
                     b.Property<int>("TipoAfiliacion")
                         .HasColumnType("int");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<decimal>("ValorMensualCOP")
                         .HasColumnType("decimal(18,2)");
@@ -1410,20 +910,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("CentroCostoId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.Property<string>("Descripcion")
                         .IsRequired()
                         .HasMaxLength(500)
@@ -1445,13 +931,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<int>("Tipo")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
                     b.HasKey("Id");
 
                     b.HasIndex("BancoId");
@@ -1466,20 +945,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("Email")
                         .IsRequired()
@@ -1506,13 +971,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int")
                         .HasDefaultValue(4);
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -1571,17 +1029,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Navigation("Miembro");
                 });
 
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Banco", b =>
-                {
-                    b.HasOne("LAMAMedellin.Domain.Entities.CuentaContable", "CuentaContable")
-                        .WithMany()
-                        .HasForeignKey("CuentaContableId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("CuentaContable");
-                });
-
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Beneficiario", b =>
                 {
                     b.HasOne("LAMAMedellin.Domain.Entities.ProyectoSocial", "ProyectoSocial")
@@ -1591,6 +1038,17 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("ProyectoSocial");
+                });
+
+            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Caja", b =>
+                {
+                    b.HasOne("LAMAMedellin.Domain.Entities.CuentaContable", "CuentaContable")
+                        .WithMany()
+                        .HasForeignKey("CuentaContableId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("CuentaContable");
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.ConceptoCobro", b =>
@@ -1660,9 +1118,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Egreso", b =>
                 {
-                    b.HasOne("LAMAMedellin.Domain.Entities.Banco", "Banco")
+                    b.HasOne("LAMAMedellin.Domain.Entities.Caja", "Caja")
                         .WithMany()
-                        .HasForeignKey("BancoId")
+                        .HasForeignKey("CajaId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
@@ -1683,7 +1141,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.Navigation("Banco");
+                    b.Navigation("Caja");
 
                     b.Navigation("CentroCosto");
 
@@ -1694,9 +1152,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Ingreso", b =>
                 {
-                    b.HasOne("LAMAMedellin.Domain.Entities.Banco", null)
+                    b.HasOne("LAMAMedellin.Domain.Entities.Caja", null)
                         .WithMany()
-                        .HasForeignKey("BancoId")
+                        .HasForeignKey("CajaId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 

--- a/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260728020913_AgregarPistaAuditoria.Designer.cs
+++ b/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260728020913_AgregarPistaAuditoria.Designer.cs
@@ -4,6 +4,7 @@ using LAMAMedellin.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LAMAMedellin.Infrastructure.Migrations
 {
     [DbContext(typeof(LamaDbContext))]
-    partial class LamaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728020913_AgregarPistaAuditoria")]
+    partial class AgregarPistaAuditoria
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -107,9 +110,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<decimal?>("CuotaAplicadaCOP")
-                        .HasColumnType("decimal(18,2)");
-
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
 
@@ -160,9 +160,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<Guid>("CuentaContableId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
 
@@ -170,18 +167,8 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<bool>("EsActivo")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(true);
-
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
-
-                    b.Property<string>("Nombre")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("NumeroCuenta")
                         .IsRequired()
@@ -200,8 +187,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("CuentaContableId");
 
                     b.HasIndex("NumeroCuenta")
                         .IsUnique();
@@ -278,6 +263,59 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsUnique();
 
                     b.ToTable("Beneficiarios", (string)null);
+                });
+
+            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Caja", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime?>("CreatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("CreatedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<Guid>("CuentaContableId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("DeletedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Nombre")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("nvarchar(150)");
+
+                    b.Property<decimal>("SaldoActual")
+                        .HasPrecision(18, 2)
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<int>("TipoCaja")
+                        .HasColumnType("int");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("UpdatedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CuentaContableId")
+                        .IsUnique();
+
+                    b.ToTable("Cajas", (string)null);
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.CentroCosto", b =>
@@ -434,19 +472,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.ToTable("ConceptosCobro", (string)null);
                 });
 
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.ConsecutivoComprobante", b =>
-                {
-                    b.Property<int>("TipoComprobante")
-                        .HasColumnType("int");
-
-                    b.Property<int>("UltimoNumero")
-                        .HasColumnType("int");
-
-                    b.HasKey("TipoComprobante");
-
-                    b.ToTable("ConsecutivosComprobante", (string)null);
-                });
-
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.CuentaContable", b =>
                 {
                     b.Property<Guid>("Id")
@@ -553,11 +578,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("MiembroId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("Periodo")
-                        .IsRequired()
-                        .HasMaxLength(7)
-                        .HasColumnType("nvarchar(7)");
-
                     b.Property<decimal>("SaldoPendiente")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("decimal(18,2)")
@@ -579,9 +599,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasIndex("ConceptoCobroId");
 
-                    b.HasIndex("MiembroId", "ConceptoCobroId", "Periodo")
+                    b.HasIndex("MiembroId", "ConceptoCobroId", "FechaEmision")
                         .IsUnique()
-                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoPeriodo");
+                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoFecha");
 
                     b.ToTable("CuentasPorCobrar", (string)null);
                 });
@@ -618,9 +638,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<int>("MesInicioCobro")
                         .HasColumnType("int");
-
-                    b.Property<decimal?>("RenovacionMembresiaUSD")
-                        .HasColumnType("decimal(18,4)");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");
@@ -777,7 +794,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("BancoId")
+                    b.Property<Guid>("CajaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("CentroCostoId")
@@ -814,9 +831,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
-
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
@@ -833,7 +847,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BancoId");
+                    b.HasIndex("CajaId");
 
                     b.HasIndex("CentroCostoId");
 
@@ -856,9 +870,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaLogisticaCOP")
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
@@ -918,7 +929,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("BancoId")
+                    b.Property<Guid>("CajaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("CentroCostoId")
@@ -955,9 +966,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
-
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
@@ -974,7 +982,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BancoId");
+                    b.HasIndex("CajaId");
 
                     b.HasIndex("CentroCostoId");
 
@@ -1069,11 +1077,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(30)
                         .HasColumnType("nvarchar(30)");
 
-                    b.Property<int>("TipoAfiliacion")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(3);
-
                     b.Property<int>("TipoSangre")
                         .HasColumnType("int");
 
@@ -1153,68 +1156,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.HasIndex("ProductoId");
 
                     b.ToTable("MovimientosInventario", (string)null);
-                });
-
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.PeriodoContable", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<int>("Anio")
-                        .HasColumnType("int");
-
-                    b.Property<string>("CerradoPor")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<int>("Estado")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime?>("FechaCierre")
-                        .HasColumnType("datetime2");
-
-                    b.Property<DateTime?>("FechaValidacionTesoreria")
-                        .HasColumnType("datetime2");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
-
-                    b.Property<int>("Mes")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<string>("ValidadoPor")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Anio", "Mes")
-                        .IsUnique()
-                        .HasDatabaseName("IX_PeriodosContables_AnioMes");
-
-                    b.ToTable("PeriodosContables", (string)null);
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Producto", b =>
@@ -1571,17 +1512,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Navigation("Miembro");
                 });
 
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Banco", b =>
-                {
-                    b.HasOne("LAMAMedellin.Domain.Entities.CuentaContable", "CuentaContable")
-                        .WithMany()
-                        .HasForeignKey("CuentaContableId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("CuentaContable");
-                });
-
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Beneficiario", b =>
                 {
                     b.HasOne("LAMAMedellin.Domain.Entities.ProyectoSocial", "ProyectoSocial")
@@ -1591,6 +1521,17 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("ProyectoSocial");
+                });
+
+            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Caja", b =>
+                {
+                    b.HasOne("LAMAMedellin.Domain.Entities.CuentaContable", "CuentaContable")
+                        .WithMany()
+                        .HasForeignKey("CuentaContableId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("CuentaContable");
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.ConceptoCobro", b =>
@@ -1660,9 +1601,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Egreso", b =>
                 {
-                    b.HasOne("LAMAMedellin.Domain.Entities.Banco", "Banco")
+                    b.HasOne("LAMAMedellin.Domain.Entities.Caja", "Caja")
                         .WithMany()
-                        .HasForeignKey("BancoId")
+                        .HasForeignKey("CajaId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
@@ -1683,7 +1624,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.Navigation("Banco");
+                    b.Navigation("Caja");
 
                     b.Navigation("CentroCosto");
 
@@ -1694,9 +1635,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Ingreso", b =>
                 {
-                    b.HasOne("LAMAMedellin.Domain.Entities.Banco", null)
+                    b.HasOne("LAMAMedellin.Domain.Entities.Caja", null)
                         .WithMany()
-                        .HasForeignKey("BancoId")
+                        .HasForeignKey("CajaId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 

--- a/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260728021651_AgregarConsecutivosComprobante.Designer.cs
+++ b/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260728021651_AgregarConsecutivosComprobante.Designer.cs
@@ -4,6 +4,7 @@ using LAMAMedellin.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LAMAMedellin.Infrastructure.Migrations
 {
     [DbContext(typeof(LamaDbContext))]
-    partial class LamaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728021651_AgregarConsecutivosComprobante")]
+    partial class AgregarConsecutivosComprobante
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -107,9 +110,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<decimal?>("CuotaAplicadaCOP")
-                        .HasColumnType("decimal(18,2)");
-
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
 
@@ -160,9 +160,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<Guid>("CuentaContableId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
 
@@ -170,18 +167,8 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<bool>("EsActivo")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(true);
-
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
-
-                    b.Property<string>("Nombre")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("NumeroCuenta")
                         .IsRequired()
@@ -200,8 +187,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("CuentaContableId");
 
                     b.HasIndex("NumeroCuenta")
                         .IsUnique();
@@ -278,6 +263,59 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsUnique();
 
                     b.ToTable("Beneficiarios", (string)null);
+                });
+
+            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Caja", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime?>("CreatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("CreatedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<Guid>("CuentaContableId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("DeletedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Nombre")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("nvarchar(150)");
+
+                    b.Property<decimal>("SaldoActual")
+                        .HasPrecision(18, 2)
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<int>("TipoCaja")
+                        .HasColumnType("int");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("UpdatedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CuentaContableId")
+                        .IsUnique();
+
+                    b.ToTable("Cajas", (string)null);
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.CentroCosto", b =>
@@ -553,11 +591,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("MiembroId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("Periodo")
-                        .IsRequired()
-                        .HasMaxLength(7)
-                        .HasColumnType("nvarchar(7)");
-
                     b.Property<decimal>("SaldoPendiente")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("decimal(18,2)")
@@ -579,9 +612,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasIndex("ConceptoCobroId");
 
-                    b.HasIndex("MiembroId", "ConceptoCobroId", "Periodo")
+                    b.HasIndex("MiembroId", "ConceptoCobroId", "FechaEmision")
                         .IsUnique()
-                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoPeriodo");
+                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoFecha");
 
                     b.ToTable("CuentasPorCobrar", (string)null);
                 });
@@ -618,9 +651,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<int>("MesInicioCobro")
                         .HasColumnType("int");
-
-                    b.Property<decimal?>("RenovacionMembresiaUSD")
-                        .HasColumnType("decimal(18,4)");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");
@@ -777,7 +807,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("BancoId")
+                    b.Property<Guid>("CajaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("CentroCostoId")
@@ -814,9 +844,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
-
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
@@ -833,7 +860,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BancoId");
+                    b.HasIndex("CajaId");
 
                     b.HasIndex("CentroCostoId");
 
@@ -856,9 +883,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaLogisticaCOP")
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
@@ -918,7 +942,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("BancoId")
+                    b.Property<Guid>("CajaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("CentroCostoId")
@@ -955,9 +979,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
-
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
@@ -974,7 +995,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BancoId");
+                    b.HasIndex("CajaId");
 
                     b.HasIndex("CentroCostoId");
 
@@ -1069,11 +1090,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(30)
                         .HasColumnType("nvarchar(30)");
 
-                    b.Property<int>("TipoAfiliacion")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(3);
-
                     b.Property<int>("TipoSangre")
                         .HasColumnType("int");
 
@@ -1153,68 +1169,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.HasIndex("ProductoId");
 
                     b.ToTable("MovimientosInventario", (string)null);
-                });
-
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.PeriodoContable", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<int>("Anio")
-                        .HasColumnType("int");
-
-                    b.Property<string>("CerradoPor")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("CreatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("CreatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("DeletedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<int>("Estado")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime?>("FechaCierre")
-                        .HasColumnType("datetime2");
-
-                    b.Property<DateTime?>("FechaValidacionTesoreria")
-                        .HasColumnType("datetime2");
-
-                    b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
-
-                    b.Property<int>("Mes")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("UpdatedBy")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<string>("ValidadoPor")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("Anio", "Mes")
-                        .IsUnique()
-                        .HasDatabaseName("IX_PeriodosContables_AnioMes");
-
-                    b.ToTable("PeriodosContables", (string)null);
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Producto", b =>
@@ -1571,17 +1525,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Navigation("Miembro");
                 });
 
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Banco", b =>
-                {
-                    b.HasOne("LAMAMedellin.Domain.Entities.CuentaContable", "CuentaContable")
-                        .WithMany()
-                        .HasForeignKey("CuentaContableId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("CuentaContable");
-                });
-
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Beneficiario", b =>
                 {
                     b.HasOne("LAMAMedellin.Domain.Entities.ProyectoSocial", "ProyectoSocial")
@@ -1591,6 +1534,17 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("ProyectoSocial");
+                });
+
+            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Caja", b =>
+                {
+                    b.HasOne("LAMAMedellin.Domain.Entities.CuentaContable", "CuentaContable")
+                        .WithMany()
+                        .HasForeignKey("CuentaContableId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("CuentaContable");
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.ConceptoCobro", b =>
@@ -1660,9 +1614,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Egreso", b =>
                 {
-                    b.HasOne("LAMAMedellin.Domain.Entities.Banco", "Banco")
+                    b.HasOne("LAMAMedellin.Domain.Entities.Caja", "Caja")
                         .WithMany()
-                        .HasForeignKey("BancoId")
+                        .HasForeignKey("CajaId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
@@ -1683,7 +1637,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.Navigation("Banco");
+                    b.Navigation("Caja");
 
                     b.Navigation("CentroCosto");
 
@@ -1694,9 +1648,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Ingreso", b =>
                 {
-                    b.HasOne("LAMAMedellin.Domain.Entities.Banco", null)
+                    b.HasOne("LAMAMedellin.Domain.Entities.Caja", null)
                         .WithMany()
-                        .HasForeignKey("BancoId")
+                        .HasForeignKey("CajaId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 

--- a/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260728142937_AgregarPeriodoContable.Designer.cs
+++ b/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260728142937_AgregarPeriodoContable.Designer.cs
@@ -4,6 +4,7 @@ using LAMAMedellin.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LAMAMedellin.Infrastructure.Migrations
 {
     [DbContext(typeof(LamaDbContext))]
-    partial class LamaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728142937_AgregarPeriodoContable")]
+    partial class AgregarPeriodoContable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -107,9 +110,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<decimal?>("CuotaAplicadaCOP")
-                        .HasColumnType("decimal(18,2)");
-
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
 
@@ -160,9 +160,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<Guid>("CuentaContableId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
 
@@ -170,18 +167,8 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<bool>("EsActivo")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(true);
-
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
-
-                    b.Property<string>("Nombre")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
 
                     b.Property<string>("NumeroCuenta")
                         .IsRequired()
@@ -200,8 +187,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("CuentaContableId");
 
                     b.HasIndex("NumeroCuenta")
                         .IsUnique();
@@ -278,6 +263,59 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsUnique();
 
                     b.ToTable("Beneficiarios", (string)null);
+                });
+
+            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Caja", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime?>("CreatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("CreatedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<Guid>("CuentaContableId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("DeletedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Nombre")
+                        .IsRequired()
+                        .HasMaxLength(150)
+                        .HasColumnType("nvarchar(150)");
+
+                    b.Property<decimal>("SaldoActual")
+                        .HasPrecision(18, 2)
+                        .HasColumnType("decimal(18,2)");
+
+                    b.Property<int>("TipoCaja")
+                        .HasColumnType("int");
+
+                    b.Property<DateTime?>("UpdatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("UpdatedBy")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CuentaContableId")
+                        .IsUnique();
+
+                    b.ToTable("Cajas", (string)null);
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.CentroCosto", b =>
@@ -553,11 +591,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("MiembroId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("Periodo")
-                        .IsRequired()
-                        .HasMaxLength(7)
-                        .HasColumnType("nvarchar(7)");
-
                     b.Property<decimal>("SaldoPendiente")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("decimal(18,2)")
@@ -579,9 +612,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasIndex("ConceptoCobroId");
 
-                    b.HasIndex("MiembroId", "ConceptoCobroId", "Periodo")
+                    b.HasIndex("MiembroId", "ConceptoCobroId", "FechaEmision")
                         .IsUnique()
-                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoPeriodo");
+                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoFecha");
 
                     b.ToTable("CuentasPorCobrar", (string)null);
                 });
@@ -618,9 +651,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<int>("MesInicioCobro")
                         .HasColumnType("int");
-
-                    b.Property<decimal?>("RenovacionMembresiaUSD")
-                        .HasColumnType("decimal(18,4)");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");
@@ -777,7 +807,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("BancoId")
+                    b.Property<Guid>("CajaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("CentroCostoId")
@@ -814,9 +844,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
-
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
@@ -833,7 +860,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BancoId");
+                    b.HasIndex("CajaId");
 
                     b.HasIndex("CentroCostoId");
 
@@ -856,9 +883,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaLogisticaCOP")
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
@@ -918,7 +942,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("BancoId")
+                    b.Property<Guid>("CajaId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("CentroCostoId")
@@ -955,9 +979,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
-
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
@@ -974,7 +995,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("BancoId");
+                    b.HasIndex("CajaId");
 
                     b.HasIndex("CentroCostoId");
 
@@ -1068,11 +1089,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsRequired()
                         .HasMaxLength(30)
                         .HasColumnType("nvarchar(30)");
-
-                    b.Property<int>("TipoAfiliacion")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(3);
 
                     b.Property<int>("TipoSangre")
                         .HasColumnType("int");
@@ -1571,17 +1587,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Navigation("Miembro");
                 });
 
-            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Banco", b =>
-                {
-                    b.HasOne("LAMAMedellin.Domain.Entities.CuentaContable", "CuentaContable")
-                        .WithMany()
-                        .HasForeignKey("CuentaContableId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("CuentaContable");
-                });
-
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Beneficiario", b =>
                 {
                     b.HasOne("LAMAMedellin.Domain.Entities.ProyectoSocial", "ProyectoSocial")
@@ -1591,6 +1596,17 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("ProyectoSocial");
+                });
+
+            modelBuilder.Entity("LAMAMedellin.Domain.Entities.Caja", b =>
+                {
+                    b.HasOne("LAMAMedellin.Domain.Entities.CuentaContable", "CuentaContable")
+                        .WithMany()
+                        .HasForeignKey("CuentaContableId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("CuentaContable");
                 });
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.ConceptoCobro", b =>
@@ -1660,9 +1676,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Egreso", b =>
                 {
-                    b.HasOne("LAMAMedellin.Domain.Entities.Banco", "Banco")
+                    b.HasOne("LAMAMedellin.Domain.Entities.Caja", "Caja")
                         .WithMany()
-                        .HasForeignKey("BancoId")
+                        .HasForeignKey("CajaId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
@@ -1683,7 +1699,7 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.Navigation("Banco");
+                    b.Navigation("Caja");
 
                     b.Navigation("CentroCosto");
 
@@ -1694,9 +1710,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
             modelBuilder.Entity("LAMAMedellin.Domain.Entities.Ingreso", b =>
                 {
-                    b.HasOne("LAMAMedellin.Domain.Entities.Banco", null)
+                    b.HasOne("LAMAMedellin.Domain.Entities.Caja", null)
                         .WithMany()
-                        .HasForeignKey("BancoId")
+                        .HasForeignKey("CajaId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 

--- a/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260728231147_ConsolidarTesoreriaEnBanco.Designer.cs
+++ b/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260728231147_ConsolidarTesoreriaEnBanco.Designer.cs
@@ -4,6 +4,7 @@ using LAMAMedellin.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LAMAMedellin.Infrastructure.Migrations
 {
     [DbContext(typeof(LamaDbContext))]
-    partial class LamaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260728231147_ConsolidarTesoreriaEnBanco")]
+    partial class ConsolidarTesoreriaEnBanco
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -106,9 +109,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaAplicadaCOP")
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
@@ -553,11 +553,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("MiembroId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("Periodo")
-                        .IsRequired()
-                        .HasMaxLength(7)
-                        .HasColumnType("nvarchar(7)");
-
                     b.Property<decimal>("SaldoPendiente")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("decimal(18,2)")
@@ -579,9 +574,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasIndex("ConceptoCobroId");
 
-                    b.HasIndex("MiembroId", "ConceptoCobroId", "Periodo")
+                    b.HasIndex("MiembroId", "ConceptoCobroId", "FechaEmision")
                         .IsUnique()
-                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoPeriodo");
+                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoFecha");
 
                     b.ToTable("CuentasPorCobrar", (string)null);
                 });
@@ -618,9 +613,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<int>("MesInicioCobro")
                         .HasColumnType("int");
-
-                    b.Property<decimal?>("RenovacionMembresiaUSD")
-                        .HasColumnType("decimal(18,4)");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");
@@ -814,9 +806,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
 
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
-
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
                         .HasColumnType("decimal(18,2)");
@@ -856,9 +845,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaLogisticaCOP")
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
@@ -954,9 +940,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<bool>("IsDeleted")
                         .HasColumnType("bit");
-
-                    b.Property<int>("MedioPago")
-                        .HasColumnType("int");
 
                     b.Property<decimal>("Monto")
                         .HasPrecision(18, 2)
@@ -1068,11 +1051,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsRequired()
                         .HasMaxLength(30)
                         .HasColumnType("nvarchar(30)");
-
-                    b.Property<int>("TipoAfiliacion")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(3);
 
                     b.Property<int>("TipoSangre")
                         .HasColumnType("int");

--- a/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260729002315_AgregarMedioPagoAMovimientos.Designer.cs
+++ b/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260729002315_AgregarMedioPagoAMovimientos.Designer.cs
@@ -4,6 +4,7 @@ using LAMAMedellin.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LAMAMedellin.Infrastructure.Migrations
 {
     [DbContext(typeof(LamaDbContext))]
-    partial class LamaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729002315_AgregarMedioPagoAMovimientos")]
+    partial class AgregarMedioPagoAMovimientos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -106,9 +109,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaAplicadaCOP")
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
@@ -553,11 +553,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<Guid>("MiembroId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("Periodo")
-                        .IsRequired()
-                        .HasMaxLength(7)
-                        .HasColumnType("nvarchar(7)");
-
                     b.Property<decimal>("SaldoPendiente")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("decimal(18,2)")
@@ -579,9 +574,9 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.HasIndex("ConceptoCobroId");
 
-                    b.HasIndex("MiembroId", "ConceptoCobroId", "Periodo")
+                    b.HasIndex("MiembroId", "ConceptoCobroId", "FechaEmision")
                         .IsUnique()
-                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoPeriodo");
+                        .HasDatabaseName("IX_CuentasPorCobrar_MiembroConceptoFecha");
 
                     b.ToTable("CuentasPorCobrar", (string)null);
                 });
@@ -618,9 +613,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
 
                     b.Property<int>("MesInicioCobro")
                         .HasColumnType("int");
-
-                    b.Property<decimal?>("RenovacionMembresiaUSD")
-                        .HasColumnType("decimal(18,4)");
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");
@@ -857,9 +849,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
 
-                    b.Property<decimal?>("CuotaLogisticaCOP")
-                        .HasColumnType("decimal(18,2)");
-
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
 
@@ -1068,11 +1057,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                         .IsRequired()
                         .HasMaxLength(30)
                         .HasColumnType("nvarchar(30)");
-
-                    b.Property<int>("TipoAfiliacion")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(3);
 
                     b.Property<int>("TipoSangre")
                         .HasColumnType("int");

--- a/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260729011546_CarteraPorPeriodoYTipoAfiliacion.Designer.cs
+++ b/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260729011546_CarteraPorPeriodoYTipoAfiliacion.Designer.cs
@@ -4,6 +4,7 @@ using LAMAMedellin.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LAMAMedellin.Infrastructure.Migrations
 {
     [DbContext(typeof(LamaDbContext))]
-    partial class LamaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729011546_CarteraPorPeriodoYTipoAfiliacion")]
+    partial class CarteraPorPeriodoYTipoAfiliacion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -106,9 +109,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaAplicadaCOP")
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");
@@ -619,9 +619,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<int>("MesInicioCobro")
                         .HasColumnType("int");
 
-                    b.Property<decimal?>("RenovacionMembresiaUSD")
-                        .HasColumnType("decimal(18,4)");
-
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("datetime2");
 
@@ -856,9 +853,6 @@ namespace LAMAMedellin.Infrastructure.Migrations
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(256)
                         .HasColumnType("nvarchar(256)");
-
-                    b.Property<decimal?>("CuotaLogisticaCOP")
-                        .HasColumnType("decimal(18,2)");
 
                     b.Property<DateTime?>("DeletedAt")
                         .HasColumnType("datetime2");

--- a/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260729144849_AplicarCuotasLogisticaYRenovacionMembresia.Designer.cs
+++ b/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260729144849_AplicarCuotasLogisticaYRenovacionMembresia.Designer.cs
@@ -4,6 +4,7 @@ using LAMAMedellin.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LAMAMedellin.Infrastructure.Migrations
 {
     [DbContext(typeof(LamaDbContext))]
-    partial class LamaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729144849_AplicarCuotasLogisticaYRenovacionMembresia")]
+    partial class AplicarCuotasLogisticaYRenovacionMembresia
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260729144849_AplicarCuotasLogisticaYRenovacionMembresia.cs
+++ b/LAMAMedellin/src/LAMAMedellin.Infrastructure/Migrations/20260729144849_AplicarCuotasLogisticaYRenovacionMembresia.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LAMAMedellin.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AplicarCuotasLogisticaYRenovacionMembresia : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Estas columnas las introdujo 20260728191700_AgregarCuotasLogisticaY
+            // RenovacionMembresia, pero esa migracion quedo sin su archivo
+            // .Designer.cs porque .gitignore excluia *.Designer.cs. Sin ese
+            // archivo no lleva el atributo [Migration], EF no la reconoce y la
+            // salta en silencio informando que la base "ya esta al dia".
+            //
+            // Esta migracion las crea de verdad. Se comprueba la existencia
+            // porque en bases donde aquella si alcanzo a aplicarse ya estarian.
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH('CuotasAsamblea', 'RenovacionMembresiaUSD') IS NULL
+                    ALTER TABLE CuotasAsamblea ADD RenovacionMembresiaUSD decimal(18,2) NULL;
+            ");
+
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH('Eventos', 'CuotaLogisticaCOP') IS NULL
+                    ALTER TABLE Eventos ADD CuotaLogisticaCOP decimal(18,2) NOT NULL DEFAULT 0;
+            ");
+
+            migrationBuilder.Sql(@"
+                IF COL_LENGTH('AsistenciasEvento', 'CuotaAplicadaCOP') IS NULL
+                    ALTER TABLE AsistenciasEvento ADD CuotaAplicadaCOP decimal(18,2) NOT NULL DEFAULT 0;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("IF COL_LENGTH('CuotasAsamblea','RenovacionMembresiaUSD') IS NOT NULL ALTER TABLE CuotasAsamblea DROP COLUMN RenovacionMembresiaUSD;");
+            migrationBuilder.Sql("IF COL_LENGTH('Eventos','CuotaLogisticaCOP') IS NOT NULL ALTER TABLE Eventos DROP COLUMN CuotaLogisticaCOP;");
+            migrationBuilder.Sql("IF COL_LENGTH('AsistenciasEvento','CuotaAplicadaCOP') IS NOT NULL ALTER TABLE AsistenciasEvento DROP COLUMN CuotaAplicadaCOP;");
+        }
+    }
+}

--- a/scripts/sql/datos-demo-limpiar.sql
+++ b/scripts/sql/datos-demo-limpiar.sql
@@ -30,7 +30,12 @@ FROM AsientosContables a
 JOIN Comprobantes c ON c.Id = a.ComprobanteId
 WHERE c.NumeroConsecutivo LIKE 'DEMO-%';
 
+DELETE i FROM Ingresos i JOIN Comprobantes c ON c.Id = i.ComprobanteContableId WHERE c.NumeroConsecutivo LIKE 'DEMO-%';
+DELETE e FROM Egresos  e JOIN Comprobantes c ON c.Id = e.ComprobanteContableId WHERE c.NumeroConsecutivo LIKE 'DEMO-%';
+
 DELETE FROM Comprobantes WHERE NumeroConsecutivo LIKE 'DEMO-%';
+
+UPDATE Bancos SET SaldoActual = 0 WHERE EsActivo = 1;
 
 DELETE cpc
 FROM CuentasPorCobrar cpc

--- a/scripts/sql/datos-demo.sql
+++ b/scripts/sql/datos-demo.sql
@@ -66,6 +66,7 @@ DECLARE @ctaDeporte   UNIQUEIDENTIFIER = (SELECT Id FROM CuentasContables WHERE 
 DECLARE @ctaOtros     UNIQUEIDENTIFIER = (SELECT Id FROM CuentasContables WHERE Codigo = '519595');
 
 DECLARE @banco        UNIQUEIDENTIFIER = (SELECT TOP 1 Id FROM Bancos);
+DECLARE @bancoActivo  UNIQUEIDENTIFIER = (SELECT TOP 1 Id FROM Bancos WHERE EsActivo = 1 ORDER BY Nombre);
 
 IF @ccCapitulo IS NULL OR @ctaCaja IS NULL OR @banco IS NULL
 BEGIN
@@ -94,19 +95,19 @@ DECLARE @movimientos TABLE (
 INSERT INTO @movimientos VALUES
     -- Mayo 2026
     ('DEMO-ING-00000001', '2026-05-05', 1, 'Recaudo cuotas de sostenimiento mayo', @ctaBanco, @ctaCuotas,    2400000, @ccCapitulo),
-    ('DEMO-ING-00000002', '2026-05-12', 1, 'Inscripciones rodada Santa Fe',        @ctaCaja,  @ctaEventos,    850000, @ccEventos),
+    ('DEMO-ING-00000002', '2026-05-12', 1, 'Inscripciones rodada Santa Fe',        @ctaBanco, @ctaEventos,    850000, @ccEventos),
     ('DEMO-EGR-00000001', '2026-05-20', 2, 'Honorarios contables mayo',            @ctaHonor, @ctaBanco,      600000, @ccFundacion),
-    ('DEMO-EGR-00000002', '2026-05-28', 2, 'Transporte logistica rodada',          @ctaTranspo, @ctaCaja,     320000, @ccEventos),
+    ('DEMO-EGR-00000002', '2026-05-28', 2, 'Transporte logistica rodada',          @ctaTranspo, @ctaBanco,     320000, @ccEventos),
     -- Junio 2026
     ('DEMO-ING-00000003', '2026-06-04', 1, 'Recaudo cuotas de sostenimiento junio', @ctaBanco, @ctaCuotas,   2550000, @ccCapitulo),
     ('DEMO-ING-00000004', '2026-06-15', 1, 'Donacion libre empresa aliada',         @ctaBanco, @ctaDonaLibre, 1500000, @ccFundacion),
-    ('DEMO-ING-00000005', '2026-06-22', 1, 'Venta de merchandising junio',          @ctaCaja,  @ctaMerch,      430000, @ccCapitulo),
+    ('DEMO-ING-00000005', '2026-06-22', 1, 'Venta de merchandising junio',          @ctaBanco, @ctaMerch,      430000, @ccCapitulo),
     ('DEMO-EGR-00000003', '2026-06-18', 2, 'Honorarios contables junio',            @ctaHonor, @ctaBanco,      600000, @ccFundacion),
     ('DEMO-EGR-00000004', '2026-06-25', 2, 'Actividad deportiva jornada social',    @ctaDeporte, @ctaBanco,    780000, @ccFundacion),
     -- Julio 2026
     ('DEMO-ING-00000006', '2026-07-03', 1, 'Recaudo cuotas de sostenimiento julio', @ctaBanco, @ctaCuotas,   2700000, @ccCapitulo),
-    ('DEMO-ING-00000007', '2026-07-14', 1, 'Inscripciones rodada Guatape',          @ctaCaja,  @ctaEventos,    920000, @ccEventos),
-    ('DEMO-ING-00000008', '2026-07-21', 1, 'Venta de merchandising julio',          @ctaCaja,  @ctaMerch,      615000, @ccCapitulo),
+    ('DEMO-ING-00000007', '2026-07-14', 1, 'Inscripciones rodada Guatape',          @ctaBanco, @ctaEventos,    920000, @ccEventos),
+    ('DEMO-ING-00000008', '2026-07-21', 1, 'Venta de merchandising julio',          @ctaBanco, @ctaMerch,      615000, @ccCapitulo),
     ('DEMO-EGR-00000005', '2026-07-16', 2, 'Honorarios contables julio',            @ctaHonor, @ctaBanco,      600000, @ccFundacion),
     ('DEMO-EGR-00000006', '2026-07-24', 2, 'Gastos varios administrativos',         @ctaOtros, @ctaBanco,      245000, @ccFundacion);
 
@@ -134,6 +135,21 @@ BEGIN
         VALUES
             (NEWID(), @comprobanteId, @cuentaDebe,  NULL, @cc, @monto, 0,      @descripcion, 0, SYSUTCDATETIME()),
             (NEWID(), @comprobanteId, @cuentaHaber, NULL, @cc, 0,      @monto, @descripcion, 0, SYSUTCDATETIME());
+
+        -- El comprobante por si solo no alcanza: el tablero y la pantalla de
+        -- tesoreria leen las tablas operativas, no el libro. Sin estas filas la
+        -- contabilidad mostraba movimiento pero tesoreria salia vacia.
+        -- MedioPago = 1 (Transferencia): el capitulo opera 100% bancarizado.
+        IF @tipo = 1
+        BEGIN
+            INSERT INTO Ingresos (Id, Fecha, Monto, Concepto, TerceroId, CuentaContableId, BancoId, CentroCostoId, ComprobanteContableId, MedioPago, IsDeleted, CreatedAt)
+            VALUES (NEWID(), @fecha, @monto, @descripcion, NULL, @cuentaHaber, @bancoActivo, @cc, @comprobanteId, 1, 0, SYSUTCDATETIME());
+        END
+        ELSE
+        BEGIN
+            INSERT INTO Egresos (Id, Fecha, Monto, Concepto, TerceroId, CuentaContableId, BancoId, CentroCostoId, ComprobanteContableId, MedioPago, IsDeleted, CreatedAt)
+            VALUES (NEWID(), @fecha, @monto, @descripcion, NULL, @cuentaDebe, @bancoActivo, @cc, @comprobanteId, 1, 0, SYSUTCDATETIME());
+        END
     END
 
     FETCH NEXT FROM cursorMovimientos INTO @consecutivo, @fecha, @tipo, @descripcion, @cuentaDebe, @cuentaHaber, @monto, @cc;
@@ -169,11 +185,15 @@ BEGIN
         FROM Miembros
         WHERE EsActivo = 1 AND IsDeleted = 0
     )
-    INSERT INTO CuentasPorCobrar (Id, MiembroId, ConceptoCobroId, FechaEmision, FechaVencimiento, ValorTotal, SaldoPendiente, Estado, IsDeleted, CreatedAt)
+    INSERT INTO CuentasPorCobrar (Id, MiembroId, ConceptoCobroId, Periodo, FechaEmision, FechaVencimiento, ValorTotal, SaldoPendiente, Estado, IsDeleted, CreatedAt)
     SELECT
         NEWID(),
         Id,
         @conceptoMensual,
+        -- Periodo YYYY-MM: es lo que hace idempotente la generacion mensual y
+        -- permite contar meses adeudados. Debe coincidir con el mes que cubre
+        -- la obligacion.
+        CASE WHEN Fila % 3 = 0 THEN '2026-05' WHEN Fila % 3 = 1 THEN '2026-06' ELSE '2026-07' END,
         CASE WHEN Fila % 3 = 0 THEN '2026-05-01' WHEN Fila % 3 = 1 THEN '2026-06-01' ELSE '2026-07-01' END,
         CASE WHEN Fila % 3 = 0 THEN '2026-05-31' WHEN Fila % 3 = 1 THEN '2026-06-30' ELSE '2026-07-31' END,
         60000,
@@ -222,6 +242,19 @@ BEGIN
         (NEWID(), @donante3,  300000, '2026-07-19', @banco, @ccFundacion, 0, 'DEMO-CERT-0003', 1, 'Consignacion en efectivo',   0, SYSUTCDATETIME());
 END
 
+-- ---------------------------------------------------------------------------
+-- 6. Saldo de la cuenta bancaria
+--
+-- Se recalcula desde los movimientos en vez de fijarlo a mano, para que el
+-- saldo que muestra el tablero coincida siempre con lo registrado.
+-- ---------------------------------------------------------------------------
+UPDATE b
+SET b.SaldoActual =
+        ISNULL((SELECT SUM(i.Monto) FROM Ingresos i WHERE i.BancoId = b.Id AND i.IsDeleted = 0), 0)
+      - ISNULL((SELECT SUM(e.Monto) FROM Egresos  e WHERE e.BancoId = b.Id AND e.IsDeleted = 0), 0)
+FROM Bancos b
+WHERE b.EsActivo = 1;
+
 COMMIT TRANSACTION;
 
 -- ---------------------------------------------------------------------------
@@ -236,7 +269,17 @@ UNION ALL SELECT 'Conceptos de cobro', COUNT(*) FROM ConceptosCobro WHERE Nombre
 UNION ALL SELECT 'Cuentas por cobrar', COUNT(*) FROM CuentasPorCobrar cpc JOIN ConceptosCobro cc ON cc.Id = cpc.ConceptoCobroId WHERE cc.Nombre LIKE 'DEMO-%'
 UNION ALL SELECT 'Productos', COUNT(*) FROM Productos WHERE CodigoSKU LIKE 'DEMO-%'
 UNION ALL SELECT 'Donantes', COUNT(*) FROM Donantes WHERE NumeroDocumento LIKE 'DEMO-%'
-UNION ALL SELECT 'Donaciones', COUNT(*) FROM Donaciones WHERE CodigoVerificacion LIKE 'DEMO-%';
+UNION ALL SELECT 'Donaciones', COUNT(*) FROM Donaciones WHERE CodigoVerificacion LIKE 'DEMO-%'
+UNION ALL SELECT 'Ingresos de tesoreria', COUNT(*) FROM Ingresos i JOIN Comprobantes c ON c.Id = i.ComprobanteContableId WHERE c.NumeroConsecutivo LIKE 'DEMO-%'
+UNION ALL SELECT 'Egresos de tesoreria', COUNT(*) FROM Egresos e JOIN Comprobantes c ON c.Id = e.ComprobanteContableId WHERE c.NumeroConsecutivo LIKE 'DEMO-%';
+
+PRINT '';
+PRINT '--- Verificacion de integridad ---';
+
+SELECT 'CxC con periodo invalido' AS Concepto,
+       CAST(COUNT(*) AS VARCHAR) AS Valor
+FROM CuentasPorCobrar
+WHERE Periodo IS NULL OR Periodo NOT LIKE '[0-9][0-9][0-9][0-9]-[0-9][0-9]';
 
 PRINT '';
 PRINT '--- Verificacion de partida doble ---';


### PR DESCRIPTION
Correcciones que salieron de intentar levantar la aplicación en local con datos de prueba. **Ninguna era un problema de datos.**

> Esta rama parte de `enhancements/tesoreria-cartera-phase1` ([#664](https://github.com/CSA-DanielVillamizar/Sistema-Contable-L.A.M.A.-Medellin/pull/664)), así que incluye sus commits. Si se mezcla este PR, #664 queda cubierto.

---

## 🔴 El bug original del proyecto reapareció

`.gitignore` excluía `*.Designer.cs`. Ese archivo es el que lleva el atributo `[Migration]`; **sin él EF Core no reconoce la clase como migración y la salta en silencio**, informando que la base *"ya está al día"*.

Es exactamente la causa que dejó 22 de 23 migraciones inservibles y obligó a colapsar el historial. Al colapsarlo **no se retiró la regla**, de modo que la primera migración que agregó el equipo cayó en lo mismo y el tablero fallaba con:

```
SqlException: Invalid column name 'CuotaLogisticaCOP'
```

Se retira la regla, con la explicación escrita al lado para que nadie la reponga.

### La consecuencia más grave del mismo origen

Los **ocho archivos `.Designer.cs` existían en disco pero nunca habían entrado al repositorio**. Las migraciones funcionaban en la máquina donde se crearon y **habrían estado rotas para cualquiera que clonara el repo** — incluido el pipeline de CI y cualquier despliegue desde cero. Ahora quedan versionados.

Se agrega además una migración que sí crea las columnas de logística y renovación de membresía, comprobando su existencia para no chocar en bases donde la original alcanzara a aplicarse.

## 🌐 CORS bloqueaba todas las llamadas

`UseHttpsRedirection` estaba **antes** de `UseCors` y respondía el preflight `OPTIONS` con un `307` hacia HTTPS. Los navegadores rechazan cualquier redirección en un preflight, así que todas las llamadas del frontend morían antes de llegar al endpoint:

```
Access to XMLHttpRequest ... blocked by CORS policy:
Response to preflight request doesn't pass access control check:
Redirect is not allowed for a preflight request.
```

`UseCors` pasa al frente, y la redirección a HTTPS queda **solo fuera de Development**, donde la API escucha en HTTP plano. Esto rompía el propio runbook local que documenta el repositorio.

## 📊 Datos de demostración incompletos

El juego de datos poblaba el libro contable pero **no las tablas operativas**, y el tablero y la pantalla de tesorería leen esas últimas: la contabilidad mostraba movimiento y tesorería salía vacía.

Es el mismo problema de **dos fuentes de verdad** que arrastra el sistema, y los datos de prueba cayeron en él.

Ahora carga también los ingresos y egresos vinculados a cada comprobante, recalcula el saldo bancario desde los movimientos en vez de fijarlo a mano, y pasa todo por la cuenta bancaria activa, coherente con la operación bancarizada.

Se corrige además que las cuentas por cobrar se insertaban **sin `Periodo`**, campo que pasó a ser obligatorio; sobre una base limpia habrían quedado obligaciones sin mes identificable. El resumen del script ahora delata períodos inválidos.

---

## Verificación

```
55 pruebas en verde
Preflight OPTIONS  →  204 con cabeceras CORS (antes 307)
/api/dashboard/resumen sin token  →  401 (antes 500)
Columnas CuotaLogisticaCOP y RenovacionMembresiaUSD  →  presentes
0 excepciones en el arranque
```

Datos cargados y contrastados: 14 comprobantes, 28 asientos cuadrados, 18 cuentas por cobrar en tres estados, 8 ingresos y 6 egresos de tesorería.

## Recomendación

Vale la pena que **cualquiera con base local la recree**, porque las migraciones que EF saltaba en silencio pudieron dejar esquemas incompletos sin avisar:

```bash
docker compose down -v && docker compose up -d
```

## 🔴 Sigue sin hacerse

Las **dos rotaciones de credenciales** señaladas desde #661. Siguen en el historial de git.
